### PR TITLE
Prepackaging causes overflow on not-super-duper-wide monitors with reasonably long timestamps - just truncate the timestamp please

### DIFF
--- a/templates/index.xhtml
+++ b/templates/index.xhtml
@@ -114,6 +114,10 @@
 			margin: auto;
 		}
 
+		.task {
+			overflow-x: hidden;
+		}
+
 		.project progress {
 			width: 13rem;
 			border: 1px solid black;
@@ -148,6 +152,8 @@
 		th.rotate > div > div {
 			width: 6em;
 		}
+		.task {
+
 	</style>
 </head>
 <body class="has-background-warning-light" style="min-height:100vh;padding:0;">


### PR DESCRIPTION
Prevent formatting error from overflow.